### PR TITLE
Use correct constant in exception handler.

### DIFF
--- a/lib/itamae/secrets/keychain.rb
+++ b/lib/itamae/secrets/keychain.rb
@@ -18,7 +18,7 @@ module Itamae
 
       def load(name)
         AesKey.load_json @path.join(name).read
-      rescue File::ENOENT
+      rescue Errno::ENOENT
         raise KeyNotFound, "Couldn't find key #{name.inspect}"
       end
 


### PR DESCRIPTION
This exception is triggered by trying to add a value when the directory specified in `.itamae-secrets.yml` doesn't exist.
