### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ on your itamae recipe, do:
 
 ``` ruby
 require 'itamae/secrets'
-node[:secrets] = Itamae::Secrets(File.join(__dir__, 'secrets'))
+node[:secrets] = Itamae::Secrets(File.join(__dir__, 'secret'))
 
 # Use it
 p node[:secrets][:awesome_secret]


### PR DESCRIPTION
Hello @sorah !!

I find a typo in README.
In sample code, this gem generates key and sets data with `--base=./secret`.
But itamae recipe sample specifies `secrets` dir.
