### PR TITLE
Support itamae-secret set --path option

### DIFF
--- a/lib/itamae/secrets/cli.rb
+++ b/lib/itamae/secrets/cli.rb
@@ -36,9 +36,12 @@ module Itamae
       desc 'set VARNAME [VALUE]', 'store value (when VALUE is omitted, read from STDIN)'
       method_option :key, type: :string, default: 'default', desc: 'key name'
       method_option :noecho, type: :boolean, desc: 'Ask one-line value with noecho when stdin is tty'
+      method_option :path, type: :string, desc: 'Path of file containing VALUE'
       def set(name, value = nil)
         value ||= if options[:noecho]
                     ask_noecho("#{name}:", false)
+                  elsif options[:path]
+                    File.read(File.expand_path(options[:path]))
                   else
                     $stdin.read.chomp
                   end


### PR DESCRIPTION
### Summary

it's enable to encrypt the value including new line.

For example, ssh private key includes new line.  
I don't want to commit private key but `itamae-secrets` can't encrypt it with provided way. 

I thought it would be convinient to use this option in situation. 

### Usage

If you give `--path` option, encrypt file contents specified `--path`.

```sh
$ bundle exec bin/itamae-secrets newkey --base=secret --method aes-random
$ bundle exec bin/itamae-secrets set --base=secret pkey --path ~/.ssh/id_rsa
$ bundle exec bin/itamae-secrets get --base=secret pkey
-----BEGIN RSA PRIVATE KEY-----
....
....
-----END RSA PRIVATE KEY-----
```