### PR TITLE
Fix store class .fetch validation message

### DIFF
--- a/lib/itamae/secrets/store.rb
+++ b/lib/itamae/secrets/store.rb
@@ -90,7 +90,7 @@ module Itamae
 
       def validate_name!(name)
         # XXX: dupe
-        raise ArgumentError, "name must not contain slashes, commas, backslackes" if name.include?("\\") || name.include?(?/) || name.include?(?:)
+        raise ArgumentError, "name must not contain slashes, colons, backslackes" if name.include?("\\") || name.include?(?/) || name.include?(?:)
       end
     end
   end

--- a/spec/itamae/secrets/store_spec.rb
+++ b/spec/itamae/secrets/store_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+RSpec.describe Itamae::Secrets::Store do
+  subject(:store) { described_class.new(base_path) }
+
+  let(:base_path) { RSPEC_TEMP_PATH }
+
+  describe '.fetch' do
+    subject(:store_fetch) { store.fetch('foo') }
+
+    context 'when arguments excced 2' do
+      subject(:store_fetch) { store.fetch('foo', 'bar', 'baz') }
+
+      it { expect { store_fetch }.to raise_error(ArgumentError) }
+    end
+
+    context 'when key is not found' do
+      it 'returns key error' do
+        expect { store_fetch }.to raise_error(KeyError, /key not found: foo/)
+      end
+    end
+
+    context 'when key is not valid' do
+      subject(:store_fetch) { store.fetch(invalid_key) }
+
+      let(:invalid_key) { %w(foo:bar foo\\bar foo/bar).sample }
+
+      it 'returns argument error for names having slashes, colons or backslashes' do
+        expect { store_fetch }
+          .to raise_error(ArgumentError, /name must not contain slashes, colons, backslackes/)
+      end
+    end
+  end
+end

--- a/spec/itamae/secrets_spec.rb
+++ b/spec/itamae/secrets_spec.rb
@@ -4,8 +4,4 @@ describe Itamae::Secrets do
   it 'has a version number' do
     expect(Itamae::Secrets::VERSION).not_to be nil
   end
-
-  it 'does something useful' do
-    expect(false).to eq(true)
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-RSPEC_TEMP_PATH = File.expand_path('../../.tmp', __FILE__)
+require 'tmpdir'
+RSPEC_TEMP_PATH = Dir.mktmpdir
 
 require 'itamae/secrets'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+
+RSPEC_TEMP_PATH = File.expand_path('../../.tmp', __FILE__)
+
 require 'itamae/secrets'


### PR DESCRIPTION
I'm creating some tests for itamae-secret projects and looking at `Itamae::Secrets::Store.fetch` I see that key validation message and behaviour are diferent.

I created this pull request to add some initial tests and make message and validation behavior consistent.

Can you help me to understand if it makes sense!? =)